### PR TITLE
修复了candidates索引错误的bug：

### DIFF
--- a/src/oc_feature_affine.cpp
+++ b/src/oc_feature_affine.cpp
@@ -102,7 +102,7 @@ namespace opencorr
 				Point2D point(px, py);
 				estimated_error = point.vectorNorm();
 				if (estimated_error < this->RANSAC_config.error_threshold) {
-					trial_set.push_back(j);
+					trial_set.push_back(candidate_index[j]);
 					location_mean_error += estimated_error;
 				}
 			}


### PR DESCRIPTION
对samples中的圆孔应力集中图片进行计算（sift+icgn2），选取upper_left_point为（30，30），POI_number_x = 220;POI_number_y = 840;grid_space = 1;发现计算所得的结果出现了一些圆形错误（如下图）。
![bd](https://user-images.githubusercontent.com/33869358/119227127-ffdd6d00-bb3e-11eb-9ca2-d424e88d4821.jpg)
经过调试发现问题出现在feature_affine compute中：由于索引错误导致超出误差阈值的点可能并没有被剔除，这些错点影响了affine_matrix的计算，从而导致ICGN迭代不收敛。
在//calculate affine matrix according to the results of concensus中，candidates的索引为max_set,因此在//concensus生成trial_set的过程中采用.push_back(j)会导致candidates的索引乱掉。修复该bug后圆形错误区域被修正（如下图）。
![ad](https://user-images.githubusercontent.com/33869358/119227124-f9e78c00-bb3e-11eb-9fe4-5f3bff6fa221.jpg)