### PR TITLE
POI设定为针对ref

### DIFF
--- a/src/oc_feature_affine.cpp
+++ b/src/oc_feature_affine.cpp
@@ -40,15 +40,15 @@ namespace opencorr
 	void FeatureAffine2D::compute(POI2D* POI) {
 		//brutal force search for neighbor keypoints
 		std::vector<Point2D> tar_candidates, ref_candidates;
-		for (int i = 0; i < this->tar_kp.size(); ++i) {
-			Point2D distance = this->tar_kp[i] - (Point2D)*POI;
+		for (int i = 0; i < this->ref_kp.size(); ++i) {
+			Point2D distance = this->ref_kp[i] - (Point2D)*POI;
 			if (distance.vectorNorm() < this->neighbor_search_radius) {
 				tar_candidates.push_back(this->tar_kp[i]);
 				ref_candidates.push_back(this->ref_kp[i]);
 			}
 		}
 
-		int candidate_number = (int)tar_candidates.size();
+		int candidate_number = (int)ref_candidates.size();
 		if (candidate_number < RANSAC_config.sample_mumber) {
 			std::cerr << "Insufficient neighbor keypoints around: " << (Point2D)*POI << std::endl;
 			return;


### PR DESCRIPTION
在oc_feature_affine中POI似乎是针对tar设置的，然而在oc_icgn中POI似乎是针对ref设置的，这样的不一致在大变形的情况下应该会引起一些bug。
且在现有的oc_feature_affine中，如果将POI设为针对tar，affine_matrix的计算在大变形下会产生bug，会导致匹配出现严重错误。
因此将POI设置为针对ref与icgn中的设定保持一致。