### PR TITLE
Fix missing <random> include in oc_feature_affine.cpp (Debian/GCC build failure)

### DIFF
--- a/src/oc_feature_affine.cpp
+++ b/src/oc_feature_affine.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <numeric>
+#include <random>
 #include <omp.h>
 
 #include "oc_feature_affine.h"


### PR DESCRIPTION
## Summary
- `FeatureAffine2D::compute` uses `std::random_device` and `std::mt19937_64` but the file never includes `<random>`.
- This builds fine on toolchains where `<random>` is pulled in transitively (MSVC, some libc++ setups), but fails on GCC/libstdc++ — i.e. most Linux distros including Debian/Ubuntu.

Fixes #17, where the fix (`#include <random>`) was already identified in the comments but never merged.

## Test plan
- [x] Confirmed the missing symbols/include by reading the file directly (`std::random_device`/`std::mt19937_64` used at two call sites, no `<random>` include anywhere in the file or its header).
- [x] One-line, additive-only change — no behavior change, just the missing standard header.