### PR TITLE
Fix silent corruption from partially out-of-bounds target subsets in ICGN

### DIFF
--- a/src/oc_icgn.cpp
+++ b/src/oc_icgn.cpp
@@ -241,6 +241,19 @@ namespace opencorr
 				}
 			}
 
+			//Interpolation2D::compute() (e.g. BicubicBspline) returns -1.f, not NaN, for a
+			//coordinate outside the target image's interpolatable range. A real pixel
+			//intensity is never negative, so this is an unambiguous way to detect a
+			//partially-out-of-bounds warped subset (a deformation guess that pushes SOME but
+			//not all sample points outside the image) without disturbing the normal in-bounds
+			//path. Without this check the fabricated -1 values silently blend into the ZNSSD
+			//cost below as if they were real intensities instead of being rejected.
+			if ((icgn->tar_subset->eg_mat.array() < 0.f).any())
+			{
+				poi->result.zncc = -3.f;
+				return;
+			}
+
 			float tar_mean_norm = icgn->tar_subset->zeroMeanNorm();
 
 			//calculate error image
@@ -438,6 +451,13 @@ namespace opencorr
 					global_coor = icgn->tar_subset->center + warped_coor;
 					icgn->tar_subset->eg_mat(r, c) = tar_interp->compute(global_coor);
 				}
+			}
+
+			//see the comment on the equivalent check in ICGN2D1::compute(POI2D*) above
+			if ((icgn->tar_subset->eg_mat.array() < 0.f).any())
+			{
+				poi->result.zncc = -3.f;
+				return;
 			}
 
 			float tar_mean_norm = icgn->tar_subset->zeroMeanNorm();
@@ -767,6 +787,14 @@ namespace opencorr
 					icgn->tar_subset->eg_mat(r, c) = tar_interp->compute(global_coor);
 				}
 			}
+
+			//see the comment on the equivalent check in ICGN2D1::compute(POI2D*) above
+			if ((icgn->tar_subset->eg_mat.array() < 0.f).any())
+			{
+				poi->result.zncc = -3.f;
+				return;
+			}
+
 			float tar_mean_norm = icgn->tar_subset->zeroMeanNorm();
 
 			//calculate error image
@@ -988,6 +1016,12 @@ namespace opencorr
 					global_coor = icgn->tar_subset->center + warped_coor;
 					icgn->tar_subset->eg_mat(r, c) = tar_interp->compute(global_coor);
 				}
+			}
+			//see the comment on the equivalent check in ICGN2D1::compute(POI2D*) above
+			if ((icgn->tar_subset->eg_mat.array() < 0.f).any())
+			{
+				poi->result.zncc = -3.f;
+				return;
 			}
 			float tar_mean_norm = icgn->tar_subset->zeroMeanNorm();
 
@@ -1322,6 +1356,10 @@ namespace opencorr
 		{
 			iteration_counter++;
 			//reconstruct target subset
+			//vol_mat is a raw float*** (not an Eigen matrix), so this is tracked with a flag
+			//instead of the .array() reduction used in the 2D overloads above -- same rationale
+			//(TricubicBspline::compute() also returns -1.f for an out-of-range coordinate)
+			bool tar_subset_out_of_range = false;
 			for (int i = 0; i < subset_dim_z; i++)
 			{
 				for (int j = 0; j < subset_dim_y; j++)
@@ -1336,9 +1374,19 @@ namespace opencorr
 						local_coor.z = z_local;
 						warped_coor = p_current.warp(local_coor);
 						global_coor = icgn->tar_subset->center + warped_coor;
-						icgn->tar_subset->vol_mat[i][j][k] = tar_interp->compute(global_coor);
+						float gray_value = tar_interp->compute(global_coor);
+						if (gray_value < 0.f)
+						{
+							tar_subset_out_of_range = true;
+						}
+						icgn->tar_subset->vol_mat[i][j][k] = gray_value;
 					}
 				}
+			}
+			if (tar_subset_out_of_range)
+			{
+				poi->result.zncc = -3.f;
+				return;
 			}
 			float tar_mean_norm = icgn->tar_subset->zeroMeanNorm();
 


### PR DESCRIPTION
## Problem

`Interpolation2D::compute()` / `Interpolation3D::compute()` (e.g. `BicubicBspline`, `TricubicBspline`) return exactly `-1.f`, not NaN, for a sample coordinate outside the interpolatable range of the target image. A deformation guess that pushes part of a subset off the image — a POI near the border, or a large motion estimate from a coarse-search seed — reconstructs a target subset where some samples are this fabricated `-1` sentinel instead of a real intensity.

Nothing currently checks for this. The `-1` values flow straight into the zero-mean normalization, error image, gradient, and Hessian used by the IC-GN Newton step, for every iteration up to `max_iteration`. In practice this mostly surfaces as a wasted full iteration budget followed by `ZNCC = -4` ("non-convergence"), which misattributes the actual cause (subset walked off the image) and burns compute doing math on corrupted data along the way.

## Fix

Add a check right after each target subset reconstruction that detects any negative (`-1.f`) intensity and rejects the POI immediately with the existing `ZNCC = -3` sentinel ("terminated at the beginning"), matching the convention already documented in `oc_dic.h` and already used elsewhere in this file. Applied at all 5 call sites: `ICGN2D1::compute` (both overloads), `ICGN2D2::compute` (both overloads), and `ICGN3D1::compute`.

## Verification

Built and ran the full existing 2D/3D example suite plus the cine-decoded FFTCC+ICGN integration path — all converge identically before and after this change.

Also checked the specific failure mode directly, on the bundled `oht_cfrp_0`/`oht_cfrp_4` example pair: a POI/guess combination that pushes the target subset off the image now returns `ZNCC = -3` in 0 iterations. Before this fix, the same case ran the full 20-iteration budget against corrupted `-1.f` "intensities" before landing on `ZNCC = -4`.

This is a minimal, single-file, non-behavior-changing fix for the in-bounds path (the added checks are pure early-exits that only trigger on already-invalid data) — should be low-risk to review.