### PR TITLE
Pin num_threads on parallel-for loops that index a fixed-size instance pool

### DIFF
--- a/src/oc_feature_affine.cpp
+++ b/src/oc_feature_affine.cpp
@@ -333,7 +333,7 @@ namespace opencorr
 	void FeatureAffine2D::compute(std::vector<POI2D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);
@@ -599,7 +599,7 @@ namespace opencorr
 	void FeatureAffine3D::compute(std::vector<POI3D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);

--- a/src/oc_fftcc.cpp
+++ b/src/oc_fftcc.cpp
@@ -277,7 +277,7 @@ namespace opencorr
 	void FFTCC2D::compute(std::vector<POI2D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);
@@ -429,7 +429,7 @@ namespace opencorr
 	void FFTCC3D::compute(std::vector<POI3D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);

--- a/src/oc_icgn.cpp
+++ b/src/oc_icgn.cpp
@@ -330,7 +330,7 @@ namespace opencorr
 	void ICGN2D1::compute(std::vector<POI2D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);
@@ -529,7 +529,7 @@ namespace opencorr
 	void ICGN2D1::compute(std::vector<POI2D>& poi_queue, std::vector<Point2D>& center_offset_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i], center_offset_queue[i]);
@@ -872,7 +872,7 @@ namespace opencorr
 	void ICGN2D2::compute(std::vector<POI2D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);
@@ -1094,7 +1094,7 @@ namespace opencorr
 	void ICGN2D2::compute(std::vector<POI2D>& poi_queue, std::vector<Point2D>& center_offset_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i], center_offset_queue[i]);
@@ -1444,7 +1444,7 @@ namespace opencorr
 	void ICGN3D1::compute(std::vector<POI3D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);

--- a/src/oc_iclm.cpp
+++ b/src/oc_iclm.cpp
@@ -360,7 +360,7 @@ namespace opencorr
 	void ICLM2D1::compute(std::vector<POI2D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);
@@ -732,7 +732,7 @@ namespace opencorr
 	void ICLM2D2::compute(std::vector<POI2D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);

--- a/src/oc_nr.cpp
+++ b/src/oc_nr.cpp
@@ -325,7 +325,7 @@ namespace opencorr
 	void NR2D1::compute(std::vector<POI2D>& poi_queue)
 	{
 		auto queue_length = poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			compute(&poi_queue[i]);

--- a/src/oc_strain.cpp
+++ b/src/oc_strain.cpp
@@ -237,7 +237,7 @@ namespace opencorr
 	void Strain::compute(std::vector<POI2D>& poi_queue)
 	{
 		int queue_length = (int)poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			if (poi_queue[i].result.zncc >= zncc_threshold)
@@ -357,7 +357,7 @@ namespace opencorr
 	void Strain::compute(std::vector<POI2DS>& poi_queue)
 	{
 		int queue_length = (int)poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			if (poi_queue[i].result.r1r2_zncc >= zncc_threshold
@@ -474,7 +474,7 @@ namespace opencorr
 	void Strain::compute(std::vector<POI3D>& poi_queue)
 	{
 		int queue_length = (int)poi_queue.size();
-#pragma omp parallel for
+#pragma omp parallel for num_threads(thread_number)
 		for (int i = 0; i < queue_length; i++)
 		{
 			if (poi_queue[i].result.zncc >= zncc_threshold)


### PR DESCRIPTION
## Problem

`ICGN2D1`/`ICGN2D2`/`ICGN3D1`, `ICLM2D1`/`ICLM2D2`, `FFTCC2D`/`FFTCC3D`, `NR2D1`, `FeatureAffine2D`/`FeatureAffine3D`, and `Strain` all follow the same pattern: the constructor allocates a `thread_number`-sized `instance_pool`, and `compute(std::vector<...>&)` runs a `#pragma omp parallel for` whose body calls `getInstance(omp_get_thread_num())` to index into that pool. `getInstance()` throws `std::string("CPU thread ID over limit")` if the `tid` it's given is `>= instance_pool.size()`.

Without `num_threads()` on the pragma, the parallel-for uses however many threads OpenMP's runtime currently has active — which doesn't have to equal `thread_number`. If a caller's ambient thread count is higher than `thread_number` when `compute()` runs (`omp_set_num_threads()` called elsewhere, `OMP_NUM_THREADS` set in the environment, or simply an earlier solver instance in the same program configured with a different thread count), some loop iterations get `omp_get_thread_num() >= instance_pool.size()`, and `getInstance()` throws from inside an OpenMP parallel region. An exception can't propagate out of a parallel region, so this calls `std::terminate()` and crashes the whole process instead of surfacing as an ordinary C++ exception at the call site.

## Fix

Add `num_threads(thread_number)` to the 15 parallel-for loops (across `oc_icgn.cpp`, `oc_iclm.cpp`, `oc_feature_affine.cpp`, `oc_nr.cpp`, `oc_strain.cpp`, `oc_fftcc.cpp`) whose body reaches `getInstance(omp_get_thread_num())`, so each of these regions always runs with exactly as many threads as the instance pool it indexes into was sized for, independent of ambient OpenMP state. This intentionally doesn't touch the other parallel-for loops in the codebase that don't use the instance-pool pattern (e.g. in `oc_sift.cpp`, `oc_gradient.cpp`) — those aren't at risk from this specific issue.

## Verification

Built and ran the existing 2D/3D example and smoke-test suite — all converge identically before and after this change.

Also reproduced the crash directly: constructing `ICGN2D1` with a small `thread_number` after the process's ambient OpenMP thread count had already been set higher (a realistic scenario — any earlier, unrelated `omp_set_num_threads()` call in the same program) crashes `ICGN2D1::compute(std::vector<POI2D>&)` with `terminate called recursively` before this change, and completes normally after it.

Small, mechanical, single-purpose change — should be easy to review alongside #25.