### PR TITLE
Fix wy/wz copy-paste bug in FeatureAffine3D::compute()

### DIFF
--- a/src/oc_feature_affine.cpp
+++ b/src/oc_feature_affine.cpp
@@ -586,7 +586,7 @@ namespace opencorr
 			poi->deformation.w = affine_matrix(3, 2);
 			poi->deformation.wx = affine_matrix(0, 2);
 			poi->deformation.wy = affine_matrix(1, 2);
-			poi->deformation.wy = affine_matrix(2, 2) - 1.f;
+			poi->deformation.wz = affine_matrix(2, 2) - 1.f;
 
 			//store results of RANSAC procedure
 			poi->result.iteration = (float)trial_counter;


### PR DESCRIPTION
## Summary
- `poi->deformation.wy` is assigned twice in `FeatureAffine3D::compute()` (`oc_feature_affine.cpp`): once from `affine_matrix(1,2)`, then again from `affine_matrix(2,2)-1.f`, which — given the `wx`/`wy`/`wz`/`w` pattern established one line above — was clearly meant for `wz`.
- `wz` is never actually assigned, so every 3D/DVC feature-guided initial guess silently drops its z-direction displacement gradient, corrupting both the ICGN3D1 warm start seeded from it and the exported `wz` column (`IO3D::saveTable3D`/`loadTable3D`).

## Test plan
- [x] Confirmed by reading the surrounding code: the assignment pattern for `u`/`v`/`w` and their gradients (`ux,uy,uz`, `vx,vy,vz`, `wx,wy,wz`) makes the intended `affine_matrix(2,2)` -> `wz` mapping unambiguous.
- [x] Verified with a synthetic keypoint cloud built from a known full 3D affine transform with distinct, nonzero `wx`/`wy`/`wz` (so the bug — `wy` colliding with `wz`'s true value, `wz` staying at zero — is unambiguous): recovers all three exactly after the fix, whereas before it they read `wy≈wz_true` and `wz≈0` regardless of the true `wz`.
- [x] One-line change, no other behavior affected.